### PR TITLE
FaultSection interface merge

### DIFF
--- a/src/org/opensha/sha/cybershake/etas/ETASModProbConfig.java
+++ b/src/org/opensha/sha/cybershake/etas/ETASModProbConfig.java
@@ -458,7 +458,7 @@ public class ETASModProbConfig extends AbstractModProbConfig {
 			IDPairing match = null;
 			
 			double origMag = sol.getRupSet().getMagForRup(fssIndex);
-			CompoundSurface surf = (CompoundSurface) sol.getRupSet().getSurfaceForRupupture(fssIndex, 1d, false);
+			CompoundSurface surf = (CompoundSurface) sol.getRupSet().getSurfaceForRupupture(fssIndex, 1d);
 			List<? extends RuptureSurface> surfs = surf.getSurfaceList();
 			Location fssFirstLoc = surfs.get(0).getFirstLocOnUpperEdge();
 			Location fssLastLoc = surfs.get(surfs.size()-1).getFirstLocOnUpperEdge();

--- a/src/org/opensha/sha/cybershake/etas/ETAS_ScenarioPageGen.java
+++ b/src/org/opensha/sha/cybershake/etas/ETAS_ScenarioPageGen.java
@@ -78,6 +78,7 @@ import org.opensha.sha.earthquake.ProbEqkRupture;
 import org.opensha.sha.earthquake.ProbEqkSource;
 import org.opensha.sha.earthquake.rupForecastImpl.WGCEP_UCERF_2_Final.UCERF2;
 import org.opensha.sha.earthquake.rupForecastImpl.WGCEP_UCERF_2_Final.MeanUCERF2.MeanUCERF2;
+import org.opensha.sha.faultSurface.FaultSection;
 import org.opensha.sha.faultSurface.RuptureSurface;
 import org.opensha.sha.imr.AttenRelRef;
 import org.opensha.sha.imr.ScalarIMR;
@@ -535,7 +536,7 @@ public class ETAS_ScenarioPageGen {
 			if (count < minRupsForParent)
 				break;
 			String parentSectionName = null;
-			for (FaultSectionPrefData sect : rupSet.getFaultSectionDataList()) {
+			for (FaultSection sect : rupSet.getFaultSectionDataList()) {
 				if (sect.getParentSectionId() == parentID) {
 					parentSectionName = sect.getParentSectionName();
 					break;
@@ -1467,8 +1468,8 @@ public class ETAS_ScenarioPageGen {
 	private File[] plotCHDs(File resourcesDir, FaultSystemRupSet rupSet, int parentSectionID, boolean plotCS) throws IOException {
 		File[] ret = new File[timeSpans.length];
 		
-		List<FaultSectionPrefData> sects = new ArrayList<>();
-		for (FaultSectionPrefData sect : rupSet.getFaultSectionDataList())
+		List<FaultSection> sects = new ArrayList<>();
+		for (FaultSection sect : rupSet.getFaultSectionDataList())
 			if (sect.getParentSectionId() == parentSectionID)
 				sects.add(sect);
 		Preconditions.checkState(!sects.isEmpty());
@@ -1636,7 +1637,7 @@ public class ETAS_ScenarioPageGen {
 			
 			if (scenarioLoc != null) {
 				double minDist = Double.POSITIVE_INFINITY;
-				for (FaultSectionPrefData sect : sects)
+				for (FaultSection sect : sects)
 					for (Location loc : sect.getFaultTrace())
 						minDist = Math.min(minDist, LocationUtils.horzDistanceFast(loc, scenarioLoc));
 				if (minDist < 10d) {
@@ -1735,7 +1736,7 @@ public class ETAS_ScenarioPageGen {
 	private boolean isHypocenterOnParentSect(int fssIndex, Location hypo, FaultSystemRupSet rupSet, int parentSectionID) {
 		double minDist = Double.POSITIVE_INFINITY;
 		boolean closestIsMatch = false;
-		for (FaultSectionPrefData sect : rupSet.getFaultSectionDataForRupture(fssIndex)) {
+		for (FaultSection sect : rupSet.getFaultSectionDataForRupture(fssIndex)) {
 			for (Location loc : sect.getFaultTrace()) {
 				double dist = LocationUtils.horzDistanceFast(hypo, loc);
 				if (dist < minDist) {

--- a/src/scratch/kevin/cybershake/SpeedTestComparisonGen.java
+++ b/src/scratch/kevin/cybershake/SpeedTestComparisonGen.java
@@ -40,8 +40,6 @@ import org.opensha.sha.imr.param.SiteParams.Vs30_Param;
 import org.opensha.sha.util.SiteTranslator;
 import org.opensha.sha.util.TectonicRegionType;
 
-import scratch.UCERF3.oldStuff.OldInversionSolutionERF;
-
 public class SpeedTestComparisonGen {
 
 	public static void main(String[] args) throws IOException {

--- a/src/scratch/kevin/cybershake/etasCalcs/InvertedU2MappingFileCreator.java
+++ b/src/scratch/kevin/cybershake/etasCalcs/InvertedU2MappingFileCreator.java
@@ -9,6 +9,7 @@ import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
 import org.opensha.sha.earthquake.ERF;
 import org.opensha.sha.earthquake.ProbEqkRupture;
 import org.opensha.sha.earthquake.ProbEqkSource;
+import org.opensha.sha.faultSurface.FaultSection;
 
 import scratch.UCERF3.inversion.CommandLineInversionRunner;
 import scratch.UCERF3.inversion.InversionFaultSystemRupSet;
@@ -44,7 +45,7 @@ public class InvertedU2MappingFileCreator {
 				ProbEqkRupture rup = source.getRupture(ruptureIndex);
 				int fssIndex = findUCERF2_Rups.getEquivFaultSystemRupIndexForUCERF2_Rupture(r);
 				if (fssIndex >= 0) {
-					List<FaultSectionPrefData> subs = rupSet.getFaultSectionDataForRupture(fssIndex);
+					List<FaultSection> subs = rupSet.getFaultSectionDataForRupture(fssIndex);
 					mapping.addLine(sourceIndex+"", ruptureIndex+"", source.getName(), rup.getMag()+"",
 							fssIndex+"", subs.get(0).getName(), subs.get(subs.size()-1).getName());
 				}

--- a/src/scratch/kevin/cybershake/etasCalcs/MappedU2SolCreator.java
+++ b/src/scratch/kevin/cybershake/etasCalcs/MappedU2SolCreator.java
@@ -13,6 +13,7 @@ import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
 import org.opensha.sha.earthquake.ERF;
 import org.opensha.sha.earthquake.ProbEqkRupture;
 import org.opensha.sha.earthquake.ProbEqkSource;
+import org.opensha.sha.faultSurface.FaultSection;
 
 import scratch.UCERF3.FaultSystemRupSet;
 import scratch.UCERF3.FaultSystemSolution;
@@ -82,7 +83,7 @@ public class MappedU2SolCreator {
 				ProbEqkRupture rup = source.getRupture(ruptureIndex);
 				int fssIndex = findUCERF2_Rups.getEquivFaultSystemRupIndexForUCERF2_Rupture(r);
 				if (fssIndex >= 0) {
-					List<FaultSectionPrefData> subs = rupSet.getFaultSectionDataForRupture(fssIndex);
+					List<FaultSection> subs = rupSet.getFaultSectionDataForRupture(fssIndex);
 					mapping.addLine(sourceIndex+"", ruptureIndex+"", source.getName(), rup.getMag()+"",
 							fssIndex+"", subs.get(0).getName(), subs.get(subs.size()-1).getName());
 				}

--- a/src/scratch/kevin/cybershake/simCompare/StudySiteHazardCurvePageGen.java
+++ b/src/scratch/kevin/cybershake/simCompare/StudySiteHazardCurvePageGen.java
@@ -38,6 +38,7 @@ import org.opensha.sha.cybershake.db.MeanUCERF2_ToDB;
 import org.opensha.sha.cybershake.db.PeakAmplitudesFromDB;
 import org.opensha.sha.earthquake.AbstractERF;
 import org.opensha.sha.earthquake.rupForecastImpl.WGCEP_UCERF_2_Final.MeanUCERF2.MeanUCERF2;
+import org.opensha.sha.faultSurface.FaultSection;
 import org.opensha.sha.faultSurface.RuptureSurface;
 import org.opensha.sha.imr.AttenRelRef;
 import org.opensha.sha.imr.ScalarIMR;
@@ -192,17 +193,17 @@ public class StudySiteHazardCurvePageGen extends SiteHazardCurveComarePageGen<CS
 			
 			for (int sourceID=0; sourceID<erf.getNumSources(); sourceID++) {
 				RSQSimSectBundledSource source = ((RSQSimSectBundledERF)erf).getSource(sourceID);
-				List<FaultSectionPrefData> sects = source.getSortedSourceSects();
+				List<FaultSection> sects = source.getSortedSourceSects();
 				double totArea = 0d;
 				List<Double> areas = new ArrayList<>();
-				for (FaultSectionPrefData sect : sects) {
+				for (FaultSection sect : sects) {
 					double area = sect.getOrigDownDipWidth()*sect.getTraceLength();
 					totArea += area;
 					areas.add(area);
 				}
 				Map<String, Double> sourceFracts = new HashMap<>();
 				for (int i=0; i<sects.size(); i++) {
-					FaultSectionPrefData sect = sects.get(i);
+					FaultSection sect = sects.get(i);
 					int id = sect.getParentSectionId();
 					String name = idsToFaultNamesMap.get(id);
 					if (name == null) {

--- a/src/scratch/kevin/cybershake/simCompare/StudySourceSiteDistPageGen.java
+++ b/src/scratch/kevin/cybershake/simCompare/StudySourceSiteDistPageGen.java
@@ -28,6 +28,7 @@ import org.opensha.sha.cybershake.db.SiteInfo2DB;
 import org.opensha.sha.cybershake.db.CybershakeIM.CyberShakeComponent;
 import org.opensha.sha.cybershake.db.CybershakeIM.IMType;
 import org.opensha.sha.earthquake.AbstractERF;
+import org.opensha.sha.faultSurface.FaultSection;
 import org.opensha.sha.imr.AttenRelRef;
 
 import com.google.common.base.Preconditions;
@@ -60,7 +61,7 @@ public class StudySourceSiteDistPageGen extends SourceSiteDistPageGen<CSRupture>
 				ret.add(rupsForSource);
 				int[] sourceParents = parentIDs.get(i);
 				for (CSRupture rup : csRuptures) {
-					for (FaultSectionPrefData sect : rsERF.getRupture(rup.getSourceID(), rup.getRupID()).getSortedSubSects()) {
+					for (FaultSection sect : rsERF.getRupture(rup.getSourceID(), rup.getRupID()).getSortedSubSects()) {
 						if (Ints.contains(sourceParents, sect.getParentSectionId())) {
 							rupsForSource.add(rup);
 							break;

--- a/src/scratch/kevin/cybershake/simulators/ruptures/SubsetBetweenCalc.java
+++ b/src/scratch/kevin/cybershake/simulators/ruptures/SubsetBetweenCalc.java
@@ -13,6 +13,7 @@ import org.apache.commons.math3.stat.StatUtils;
 import org.opensha.commons.data.CSVFile;
 import org.opensha.commons.util.DataUtils;
 import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
+import org.opensha.sha.faultSurface.FaultSection;
 import org.opensha.sha.simulators.RSQSimEvent;
 
 import com.google.common.base.Preconditions;
@@ -55,7 +56,7 @@ public class SubsetBetweenCalc {
 		for (RSQSimEvent event : eventsMap.values()) {
 			Integer eventID = event.getID();
 			HashSet<Integer> parents = new HashSet<>();
-			for (FaultSectionPrefData sect : catalog.getSubSectsForRupture(event))
+			for (FaultSection sect : catalog.getSubSectsForRupture(event))
 				parents.add(sect.getParentSectionId());
 			eventParentsMap.put(eventID, parents);
 		}

--- a/src/scratch/kevin/cybershake/ucerf3/safWallToWallTests/FSS_ERF2DB.java
+++ b/src/scratch/kevin/cybershake/ucerf3/safWallToWallTests/FSS_ERF2DB.java
@@ -64,15 +64,14 @@ public class FSS_ERF2DB extends ERF2DB {
 		}
 
 		@Override
-		public synchronized RuptureSurface getSurfaceForRupupture(int rupIndex, double gridSpacing,
-				boolean quadRupSurface) {
+		public synchronized RuptureSurface getSurfaceForRupupture(int rupIndex, double gridSpacing) {
 			// use global grid spacing
 			gridSpacing = this.createGridSpacing;
 			RuptureSurface cached = surfCache.get(rupIndex);
 			if (cached != null)
 				return cached;
 			
-			RuptureSurface combSurface = super.getSurfaceForRupupture(rupIndex, gridSpacing, quadRupSurface);
+			RuptureSurface combSurface = super.getSurfaceForRupupture(rupIndex, gridSpacing);
 			double aveTopDepth = combSurface.getAveRupTopDepth();
 			double aveWidth = combSurface.getAveWidth();
 			

--- a/src/scratch/kevin/cybershake/ucerf3/safWallToWallTests/GMPEComparisonPlotter.java
+++ b/src/scratch/kevin/cybershake/ucerf3/safWallToWallTests/GMPEComparisonPlotter.java
@@ -28,6 +28,7 @@ import org.opensha.sha.cybershake.db.Cybershake_OpenSHA_DBApplication;
 import org.opensha.sha.cybershake.db.DBAccess;
 import org.opensha.sha.cybershake.db.SiteInfo2DB;
 import org.opensha.sha.earthquake.EqkRupture;
+import org.opensha.sha.faultSurface.FaultSection;
 import org.opensha.sha.faultSurface.RuptureSurface;
 import org.opensha.sha.gui.infoTools.IMT_Info;
 import org.opensha.sha.imr.AttenRelRef;
@@ -143,11 +144,11 @@ public class GMPEComparisonPlotter {
 		return ret;
 	}
 	
-	static void printRupSections(List<FaultSectionPrefData> sects) {
+	static void printRupSections(List<FaultSection> sects) {
 		String firstForParent = null;
 		String prevParent = null;
 		String prevSub = null;
-		for (FaultSectionPrefData sect : sects) {
+		for (FaultSection sect : sects) {
 			String parent = sect.getParentSectionName();
 			if (!parent.equals(prevParent)) {
 				// new parent section
@@ -177,9 +178,9 @@ public class GMPEComparisonPlotter {
 	}
 	
 	static int getLargestSubRupInRegion(FaultSystemRupSet rupSet, int origRupIndex, Region region) {
-		List<FaultSectionPrefData> origSects = rupSet.getFaultSectionDataForRupture(origRupIndex);
+		List<FaultSection> origSects = rupSet.getFaultSectionDataForRupture(origRupIndex);
 		HashSet<Integer> allowedSectionIndices = new HashSet<Integer>();
-		for (FaultSectionPrefData sect : origSects) {
+		for (FaultSection sect : origSects) {
 			boolean inside = true;
 			for (Location loc : sect.getFaultTrace())
 				if (!region.contains(loc))
@@ -210,7 +211,7 @@ public class GMPEComparisonPlotter {
 	}
 	
 	static EqkRupture getRup(FaultSystemRupSet rupSet, int rupIndex) {
-		RuptureSurface surf = rupSet.getSurfaceForRupupture(rupIndex, 1d, false);
+		RuptureSurface surf = rupSet.getSurfaceForRupupture(rupIndex, 1d);
 		return new EqkRupture(rupSet.getMagForRup(rupIndex), rupSet.getAveRakeForRup(rupIndex), surf, null);
 	}
 

--- a/src/scratch/kevin/cybershake/ucerf3/safWallToWallTests/SubsetSolutionGenerator.java
+++ b/src/scratch/kevin/cybershake/ucerf3/safWallToWallTests/SubsetSolutionGenerator.java
@@ -12,6 +12,7 @@ import org.opensha.commons.geo.Location;
 import org.opensha.commons.geo.Region;
 import org.opensha.refFaultParamDb.vo.FaultSectionPrefData;
 import org.opensha.sha.faultSurface.CompoundSurface;
+import org.opensha.sha.faultSurface.FaultSection;
 import org.opensha.sha.faultSurface.RuptureSurface;
 
 import com.google.common.collect.Lists;
@@ -39,7 +40,7 @@ public class SubsetSolutionGenerator {
 		
 		Map<Integer, Boolean> safSectsInSoCal = Maps.newHashMap();
 		for (int sectIndex=0; sectIndex<rupSet.getNumSections(); sectIndex++) {
-			FaultSectionPrefData sect = rupSet.getFaultSectionData(sectIndex);
+			FaultSection sect = rupSet.getFaultSectionData(sectIndex);
 			if (!parents.contains(sect.getParentSectionId()))
 				continue;
 			boolean inside = false;
@@ -115,7 +116,7 @@ public class SubsetSolutionGenerator {
 		System.out.println("Longest All SAF: "+longestSAF);
 		System.out.println("Longest So Cal SAF: "+longestSAF_soCal);
 		
-		CompoundSurface surf = (CompoundSurface) rupSet.getSurfaceForRupupture(longestSAF, 1d, false);
+		CompoundSurface surf = (CompoundSurface) rupSet.getSurfaceForRupupture(longestSAF, 1d);
 		System.out.println();
 		System.out.println("Longest Rupture:");
 		System.out.println("\tLength: "+longestSAFLength+" (km)");
@@ -144,9 +145,8 @@ public class SubsetSolutionGenerator {
 		for (double gridSpacing : gridSpacings) {
 			long count = 0;
 			
-			for (FaultSectionPrefData sect : rupSet.getFaultSectionDataList()) {
-				count += sect.getStirlingGriddedSurface(gridSpacing).size();
-			}
+			for (FaultSection sect : rupSet.getFaultSectionDataList())
+				count += sect.getFaultSurface(gridSpacing).getEvenlyDiscretizedNumLocs();
 			
 			System.out.println((int)(gridSpacing*1000d)+"m: "+count);
 		}


### PR DESCRIPTION
Massive refactor to replace references to FaultSectionPrefData with new FaultSection interface. This allows multiple types of fault sections to be used in a fault system rupture set/solution. FaultSections can also specify their own rupture surface implementation, which is returned via getRuptureSurface(...). Stirling (or even gridded) surfaces are no longer assumed.

Corresponds with https://github.com/opensha/opensha-ucerf3/pull/6 and https://github.com/opensha/opensha-dev/pull/27